### PR TITLE
Fix build script and Makefile for Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Makefile.local
 *tags
 misc/patches
 misc/last-merged-ioq3-revision.temp
+.DS_Store
+*.orig

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,7 @@ ifeq ($(PLATFORM),darwin)
     BASE_CFLAGS += -arch i386 -m32 -mstackrealign
   endif
   ifeq ($(ARCH),x86_64)
-    OPTIMIZEVM += -arch x86_64 -mfpmath=sse
+    OPTIMIZEVM += -arch x86_64
   endif
 
   # When compiling on OSX for OSX, we're not cross compiling as far as the
@@ -468,12 +468,11 @@ ifeq ($(PLATFORM),darwin)
     $(LIBSDIR)/macosx/libSDL-1.2.0.dylib
   RENDERER_LIBS += -framework OpenGL $(LIBSDIR)/macosx/libSDL-1.2.0.dylib
 
-  OPTIMIZEVM += -falign-loops=16
-  OPTIMIZE = $(OPTIMIZEVM) -ffast-math
+  OPTIMIZE = -Ofast -flto
 
   SHLIBEXT=dylib
   SHLIBCFLAGS=-fPIC -fno-common
-  SHLIBLDFLAGS=-dynamiclib $(LDFLAGS) -Wl,-U,_com_altivec
+  SHLIBLDFLAGS=-dynamiclib -flto $(LDFLAGS) -Wl,-U,_com_altivec
 
   NOTSHLIBCFLAGS=-mdynamic-no-pic
 

--- a/make-macosx.sh
+++ b/make-macosx.sh
@@ -29,7 +29,7 @@ if [ -z "$DARWIN_GCC_ARCH" ]; then
 	DARWIN_GCC_ARCH=${BUILDARCH}
 fi
 
-CC=gcc-4.0
+CC=clang
 APPBUNDLE=Tremulous.app
 BINARY=tremulous.${BUILDARCH}
 DEDBIN=tremded.${BUILDARCH}
@@ -152,6 +152,6 @@ cp $BIN_OBJ $DESTDIR/$APPBUNDLE/Contents/MacOS/$BINARY
 cp $BIN_DEDOBJ $DESTDIR/$APPBUNDLE/Contents/MacOS/$DEDBIN
 cp $RENDER_OBJ $DESTDIR/$APPBUNDLE/Contents/MacOS/
 cp $BASE_OBJ $DESTDIR/$APPBUNDLE/Contents/MacOS/$BASEDIR/
-cp code/libs/macosx/*.dylib $DESTDIR/$APPBUNDLE/Contents/MacOS/
-cp code/libs/macosx/*.dylib $DESTDIR
+cp src/libs/macosx/*.dylib $DESTDIR/$APPBUNDLE/Contents/MacOS/
+cp src/libs/macosx/*.dylib $DESTDIR
 


### PR DESCRIPTION
Removed some outdated build flags, set maximum optimization level, and fixed the build scripts.