### PR TITLE
Quick fix for SDL_SetGamma crash on Mac OS 10.9

### DIFF
--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -727,13 +727,22 @@ success:
 	// This values force the UI to disable driver selection
 	glConfig.driverType = GLDRV_ICD;
 	glConfig.hardwareType = GLHW_GENERIC;
+    
+    // Remove call to SDL_SetGamma for Mac OS X
+    // It causes a crash, but is apparently fixed in SDL2
+    // somewhere upstream in ioq3. For more details, see
+    // http://www.ioquake.org/forums/viewtopic.php?f=12&t=1928
+#ifndef MACOS_X
 	glConfig.deviceSupportsGamma = SDL_SetGamma( 1.0f, 1.0f, 1.0f ) >= 0;
-
+#endif
+    
 	// Mysteriously, if you use an NVidia graphics card and multiple monitors,
 	// SDL_SetGamma will incorrectly return false... the first time; ask
 	// again and you get the correct answer. This is a suspected driver bug, see
 	// http://bugzilla.icculus.org/show_bug.cgi?id=4316
+#ifndef MACOS_X
 	glConfig.deviceSupportsGamma = SDL_SetGamma( 1.0f, 1.0f, 1.0f ) >= 0;
+#endif
 
 	if ( -1 == r_ignorehwgamma->integer)
 		glConfig.deviceSupportsGamma = 1;


### PR DESCRIPTION
Apparently SDL 1.2 crashes on 10.9 during `SDL_SetGamma`. This is apparently fixed upstream in ioquake3 when using SDL 2.0, but I haven't been able to merge the new changes successfully yet. More details here: http://www.ioquake.org/forums/viewtopic.php?f=12&t=1928

```
0 com.apple.CoreGraphics 0x996d010b interpolate_table + 160
1 com.apple.CoreGraphics 0x996cffc6 CGSGetDisplayTransferByTable + 247
2 libSDL-1.2.0.dylib 0x01ab736f QZ_GetGammaRamp + 105
3 libSDL-1.2.0.dylib 0x01aa8f4f SDL_GetGammaRamp + 230
4 libSDL-1.2.0.dylib 0x01aa90ee SDL_SetGammaRamp + 326
5 libSDL-1.2.0.dylib 0x01aa9380 SDL_SetGamma + 401
```