### PR TITLE
Changes from /dev/humancontroller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endif
 export CROSS_COMPILING
 
 ifndef VERSION
-VERSION=1.2.0
+VERSION=gpp1
 endif
 
 ifndef CLIENTBIN

--- a/assets/ui/joinserver.menu
+++ b/assets/ui/joinserver.menu
@@ -294,7 +294,7 @@
       action
       {
         play "sound/misc/menu1.wav";
-        uiScript ServerSort 1;
+        uiScript ServerSort 4;
 
         setitemcolor grpColumn backcolor 0 0 0 0;
         setitemcolor grpTabs backcolor 0 0 0 0;
@@ -338,7 +338,7 @@
       action
       {
         play "sound/misc/menu1.wav";
-        uiScript ServerSort 2;
+        uiScript ServerSort 1;
 
         setitemcolor grpColumn backcolor 0 0 0 0;
         setitemcolor grpTabs backcolor 0 0 0 0;
@@ -382,7 +382,7 @@
       action
       {
         play "sound/misc/menu1.wav";
-        uiScript ServerSort 3;
+        uiScript ServerSort 2;
 
         setitemcolor grpColumn backcolor 0 0 0 0;
         setitemcolor grpTabs backcolor 0 0 0 0;
@@ -426,7 +426,7 @@
       action
       {
         play "sound/misc/menu1.wav";
-        uiScript ServerSort 4;
+        uiScript ServerSort 3;
 
         setitemcolor grpColumn backcolor 0 0 0 0;
         setitemcolor grpTabs backcolor 0 0 0 0;

--- a/src/cgame/cg_main.c
+++ b/src/cgame/cg_main.c
@@ -164,6 +164,7 @@ vmCvar_t  cg_noPrintDuplicate;
 vmCvar_t  cg_noVoiceChats;
 vmCvar_t  cg_noVoiceText;
 vmCvar_t  cg_hudFiles;
+vmCvar_t  cg_hudFilesEnable;
 vmCvar_t  cg_smoothClients;
 vmCvar_t  pmove_fixed;
 vmCvar_t  pmove_msec;
@@ -308,6 +309,7 @@ static cvarTable_t cvarTable[ ] =
   { &cg_disableScannerPlane, "cg_disableScannerPlane", "0", CVAR_ARCHIVE },
   { &cg_tutorial, "cg_tutorial", "1", CVAR_ARCHIVE },
   { &cg_hudFiles, "cg_hudFiles", "ui/hud.txt", CVAR_ARCHIVE},
+  { &cg_hudFilesEnable, "cg_hudFilesEnable", "0", CVAR_ARCHIVE},
   { NULL, "cg_alienConfig", "", CVAR_ARCHIVE },
   { NULL, "cg_humanConfig", "", CVAR_ARCHIVE },
   { NULL, "cg_spectatorConfig", "", CVAR_ARCHIVE },
@@ -1684,7 +1686,7 @@ void CG_LoadHudMenu( void )
   trap_Cvar_VariableStringBuffer( "cg_hudFiles", buff, sizeof( buff ) );
   hudSet = buff;
 
-  if( hudSet[ 0 ] == '\0' )
+  if( !cg_hudFilesEnable.integer || hudSet[ 0 ] == '\0' )
     hudSet = "ui/hud.txt";
 
   CG_LoadMenus( hudSet );

--- a/src/cgame/cg_weapons.c
+++ b/src/cgame/cg_weapons.c
@@ -767,7 +767,7 @@ void CG_RegisterWeapon( int weaponNum )
   Com_sprintf( path, MAX_QPATH, "models/weapons/%s/animation.cfg", BG_Weapon( weaponNum )->name );
 
   if( !CG_ParseWeaponAnimationFile( path, weaponInfo ) )
-    Com_Printf( S_COLOR_RED "ERROR: failed to parse %s\n", path );
+    ; //Com_Printf( S_COLOR_RED "ERROR: failed to parse %s\n", path );
 
   // calc midpoint for rotation
   trap_R_ModelBounds( weaponInfo->weaponModel, mins, maxs );

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -4168,25 +4168,9 @@ void CL_GlobalServers_f( void ) {
 	cls.numglobalservers = -1;
 	cls.pingUpdateSource = AS_GLOBAL;
 
-	// Use the extended query for IPv6 masters
-	if (to.type == NA_IP6 || to.type == NA_MULTICAST6)
-	{
-		int v4enabled = Cvar_VariableIntegerValue("net_enabled") & NET_ENABLEV4;
-		
-		if(v4enabled)
-		{
-			Com_sprintf(command, sizeof(command), "getserversExt %s %s",
-				com_gamename->string, Cmd_Argv(2));
-		}
-		else
-		{
-			Com_sprintf(command, sizeof(command), "getserversExt %s %s ipv6",
-				com_gamename->string, Cmd_Argv(2));
-		}
-	}
-	else
-		Com_sprintf(command, sizeof(command), "getservers %s %s",
-			com_gamename->string, Cmd_Argv(2));
+	Com_sprintf(command, sizeof(command), "getserversExt %s %i%s",
+		com_gamename->string, PROTOCOL_VERSION,
+		(Cvar_VariableIntegerValue("net_enabled") & NET_ENABLEV4 ? "" : " ipv6"));
 
 	for (i=3; i < count; i++)
 	{

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -271,7 +271,7 @@ static cvarTable_t   gameCvarTable[ ] =
 
   { &g_censorship, "g_censorship", "", CVAR_ARCHIVE, 0, qfalse  },
 
-  { &g_tag, "g_tag", "main", CVAR_INIT, 0, qfalse }
+  { &g_tag, "g_tag", "gpp", CVAR_INIT, 0, qfalse }
 };
 
 static size_t gameCvarTableSize = ARRAY_LEN( gameCvarTable );

--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -3202,7 +3202,7 @@ static void FS_Startup( const char *gameName )
 		homePath = fs_basepath->string;
 	}
 	fs_homepath = Cvar_Get ("fs_homepath", homePath, CVAR_INIT|CVAR_PROTECTED );
-	fs_gamedirvar = Cvar_Get ("fs_game", "", CVAR_INIT|CVAR_SYSTEMINFO );
+	fs_gamedirvar = Cvar_Get ("fs_game", "gpp", CVAR_INIT|CVAR_SYSTEMINFO );
 
 	// add search path elements in reverse priority order
 	if (fs_basepath->string[0]) {

--- a/src/qcommon/qcommon.h
+++ b/src/qcommon/qcommon.h
@@ -256,7 +256,7 @@ extern int demo_protocols[];
 #define MASTER_SERVER_NAME	"master.tremulous.net"
 #endif
 
-#define	PORT_MASTER			30710
+#define	PORT_MASTER			30700
 #define	PORT_SERVER			30720
 #define	NUM_SERVER_PORTS	4		// broadcast scan this many ports after
 									// PORT_SERVER so a single machine can

--- a/src/renderergl1/tr_init.c
+++ b/src/renderergl1/tr_init.c
@@ -960,8 +960,8 @@ void R_Register( void )
 	r_ignorehwgamma = ri.Cvar_Get( "r_ignorehwgamma", "0", CVAR_ARCHIVE | CVAR_LATCH);
 	r_fullscreen = ri.Cvar_Get( "r_fullscreen", "1", CVAR_ARCHIVE );
 	r_noborder = ri.Cvar_Get("r_noborder", "0", CVAR_ARCHIVE | CVAR_LATCH);
-	r_width = ri.Cvar_Get( "r_width", "640", CVAR_ARCHIVE | CVAR_LATCH );
-	r_height = ri.Cvar_Get( "r_height", "480", CVAR_ARCHIVE | CVAR_LATCH );
+	r_width = ri.Cvar_Get( "r_width", "0", CVAR_ARCHIVE | CVAR_LATCH );
+	r_height = ri.Cvar_Get( "r_height", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	r_pixelAspect = ri.Cvar_Get( "r_pixelAspect", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_simpleMipMaps = ri.Cvar_Get( "r_simpleMipMaps", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_vertexLight = ri.Cvar_Get( "r_vertexLight", "0", CVAR_ARCHIVE | CVAR_LATCH );

--- a/src/renderergl2/tr_init.c
+++ b/src/renderergl2/tr_init.c
@@ -1098,8 +1098,8 @@ void R_Register( void )
 	r_mode = ri.Cvar_Get( "r_mode", "-2", CVAR_ARCHIVE | CVAR_LATCH );
 	r_fullscreen = ri.Cvar_Get( "r_fullscreen", "1", CVAR_ARCHIVE );
 	r_noborder = ri.Cvar_Get("r_noborder", "0", CVAR_ARCHIVE | CVAR_LATCH);
-	r_width = ri.Cvar_Get( "r_width", "640", CVAR_ARCHIVE | CVAR_LATCH );
-	r_height = ri.Cvar_Get( "r_height", "480", CVAR_ARCHIVE | CVAR_LATCH );
+	r_width = ri.Cvar_Get( "r_width", "0", CVAR_ARCHIVE | CVAR_LATCH );
+	r_height = ri.Cvar_Get( "r_height", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	r_pixelAspect = ri.Cvar_Get( "r_pixelAspect", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_simpleMipMaps = ri.Cvar_Get( "r_simpleMipMaps", "1", CVAR_ARCHIVE | CVAR_LATCH );
 	r_vertexLight = ri.Cvar_Get( "r_vertexLight", "0", CVAR_ARCHIVE | CVAR_LATCH );

--- a/src/sdl/sdl_glimp.c
+++ b/src/sdl/sdl_glimp.c
@@ -261,9 +261,14 @@ static int GLimp_SetMode( qboolean failSafe, qboolean fullscreen, qboolean nobor
 
 	if( !failSafe )
 	{
-		// use desktop video resolution
-		if( desktopMode.h > 0 )
+		if( r_width->integer > 0 && r_height->integer > 0 )
 		{
+			glConfig.vidWidth = r_width->integer;
+			glConfig.vidHeight = r_height->integer;
+		}
+		else if( desktopMode.h > 0 )
+		{
+			// use desktop video resolution
 			glConfig.vidWidth = desktopMode.w;
 			glConfig.vidHeight = desktopMode.h;
 		}

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -665,8 +665,7 @@ void SV_Init (void)
 	Cvar_Get ("sv_dlURL", "http://downloads.tremulous.net", CVAR_SERVERINFO | CVAR_ARCHIVE);
 	
 	sv_master[0] = Cvar_Get("sv_master1", MASTER_SERVER_NAME, 0);
-	sv_master[1] = Cvar_Get("sv_master2", "master.ioquake3.org", 0);
-	for(index = 2; index < MAX_MASTER_SERVERS; index++)
+	for(index = 1; index < MAX_MASTER_SERVERS; index++)
 		sv_master[index] = Cvar_Get(va("sv_master%d", index + 1), "", CVAR_ARCHIVE);
 
 	sv_reconnectlimit = Cvar_Get ("sv_reconnectlimit", "3", 0);

--- a/src/ui/ui_main.c
+++ b/src/ui/ui_main.c
@@ -1120,7 +1120,7 @@ static void UI_StartServerRefresh( qboolean full )
   {
     qboolean global = ui_netSource.integer == AS_GLOBAL;
 
-    trap_Cmd_ExecuteText( EXEC_APPEND, va( "globalservers %d full empty\n",
+    trap_Cmd_ExecuteText( EXEC_APPEND, va( "globalservers %d 70 full empty\n",
                           global ? 0 : 1 ) );
   }
 }

--- a/src/ui/ui_public.h
+++ b/src/ui/ui_public.h
@@ -152,10 +152,10 @@ uiMenuCommand_t;
 typedef enum
 {
   SORT_HOST,
-  SORT_GAME,
   SORT_MAP,
   SORT_CLIENTS,
-  SORT_PING
+  SORT_PING,
+  SORT_GAME
 }
 serverSortField_t;
 


### PR DESCRIPTION
I'm not sure if these changes are wanted; the future of darklegion/tremulous is unclear.  Perhaps a gpp-compat branch should be created?  Feedback is appreciated.

IRC log:

    <DevHC> p0 fixes a major usability issue: r_width and r_height get
            practically ignored
    <DevHC> the rest r more or less [resolve a few gpp] compatibility issues
            with the latest build
    <DevHC> p1 is just in case someone mixes server/client binaries and QVMs
            of different versions -- GPP1 vs GitHub-latest
    <DevHC> p2, at least in my testing, is required to get a server listing
            working
    <DevHC> u'd think that the QVM should say "globalservers %d 71 full 
            empty" (instead of 70 there); here's how this works: old GPP 
            binaries use the 70 (correct, the GPP release uses protocol 70), 
            while the (newly-patched) GitHub-latest builds ignore the number 
            and use 71 (also correct)
    <DevHC> p3: to try to avoid loading incompatible QVMs, and to stop 
            fooling the stats aggregators
    <DevHC> p4: meh...