### PR TITLE
change BASEGAME to gpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ SERVERBIN=tremded
 endif
 
 ifndef BASEGAME
-BASEGAME=base
+BASEGAME=gpp
 endif
 
 ifndef BASEGAME_CFLAGS


### PR DESCRIPTION
allow a newly built client to use the default fs_game (gpp) to find game/cgame/ui modules from the build directory