### PR TITLE
let fs_basegame default to gpp

### DIFF
--- a/src/qcommon/files.c
+++ b/src/qcommon/files.c
@@ -3196,7 +3196,7 @@ static void FS_Startup( const char *gameName )
 
 	fs_debug = Cvar_Get( "fs_debug", "0", 0 );
 	fs_basepath = Cvar_Get ("fs_basepath", Sys_DefaultInstallPath(), CVAR_INIT|CVAR_PROTECTED );
-	fs_basegame = Cvar_Get ("fs_basegame", "", CVAR_INIT );
+	fs_basegame = Cvar_Get ("fs_basegame", "gpp", CVAR_INIT );
 	homePath = Sys_DefaultHomePath();
 	if (!homePath || !homePath[0]) {
 		homePath = fs_basepath->string;


### PR DESCRIPTION
another patch from /dev/humancontroller

>also let fs_basegame default to "gpp"
>
>otherwise, the client won't find a loadable ui module when first connecting to a server with a non-"gpp" mod
