### PR TITLE
Trivial fixes

### DIFF
--- a/src/game/g_buildable.c
+++ b/src/game/g_buildable.c
@@ -100,7 +100,7 @@ gentity_t *G_CheckSpawnPoint( int spawnNum, const vec3_t origin,
   if( tr.entityNum != ENTITYNUM_NONE )
     return &g_entities[ tr.entityNum ];
 
-  trap_Trace( &tr, localOrigin, cmins, cmaxs, localOrigin, -1, MASK_PLAYERSOLID );
+  trap_Trace( &tr, localOrigin, cmins, cmaxs, localOrigin, ENTITYNUM_NONE, MASK_PLAYERSOLID );
 
   if( tr.entityNum != ENTITYNUM_NONE )
     return &g_entities[ tr.entityNum ];

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -2311,7 +2311,7 @@ void Cmd_Sell_f( gentity_t *ent )
 
     //if we have this weapon selected, force a new selection
     if( weapon == selected )
-      G_ForceWeaponChange( ent, WP_NONE );
+      G_ForceWeaponChange( ent, WP_BLASTER );
   }
   else if( upgrade != UP_NONE )
   {


### PR DESCRIPTION
- passEntityNum must not < 0
- Selling a weapon was leaving weapon in players hands.
